### PR TITLE
feat: Add structured data for SoftwareApplication

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,34 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Google Maps Timeline Data Converter App</title>
     <meta name="description" content="A web app to clean, parse, and convert Google Maps Timeline data into CSV, KML, and JSON formats." />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Google Maps Timeline Data Converter",
+        "description": "A web app to clean, parse, and convert Google Maps Timeline data into CSV, KML, and JSON formats.",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        },
+        "author": {
+          "@type": "Person",
+          "name": "Brandon Scivolette",
+          "url": "https://github.com/BrandonML"
+        },
+        "url": "https://brandonml.github.io/google-maps-timeline-converter/",
+        "isAccessibleForFree": true,
+        "sourceOrganization": {
+          "@type": "Organization",
+          "name": "Brandon Scivolette",
+          "url": "https://github.com/BrandonML"
+        },
+        "softwareApplicationSubtype": "WebApplication"
+      }
+    </script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Adds JSON-LD structured data to the `index.html` file to define the web application as a `SoftwareApplication` in accordance with schema.org standards.

This change includes the following details:
- Defines the application as a `WebApplication`.
- Sets the category to `UtilitiesApplication`.
- Specifies that the application is free and runs in any browser.
- Includes developer information, linking to the author's GitHub profile.
- Marks the application as open source.